### PR TITLE
Optional value unwrap crash fix

### DIFF
--- a/Sources/Regex/Utilities.swift
+++ b/Sources/Regex/Utilities.swift
@@ -23,8 +23,10 @@ extension String {
             // lazily-bridged NSString. But it can change in the future.
             return true
         }
-        let cocoaStringClass: AnyClass = NSClassFromString("__NSCFString")!
-        return (self as NSString).isKind(of: cocoaStringClass)
+        if let stringClass = NSClassFromString("__NSCFString") {
+            return (self as NSString).isKind(of: stringClass)
+        }
+        return false
     }
     
     func makeCocoa() -> NSString {


### PR DESCRIPTION
When deploying this swift package in a Docker container, `NSClassFromString("__NSCFString")` returns `nil` and causes the crash.
`Regex/Utilities.swift:26: Fatal error: Unexpectedly found nil while unwrapping an Optional value`